### PR TITLE
Add react-native wrapper for our serialization lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ name / link       | description                                    | Byron      
 
 ## SDK
 
-Name / Link                 | Description                                                              | Haskell            | JavaScript
----                         | ---                                                                      | ---                | ---
-[bech32]                    | Human-friendly Bech32 address encoding                                   | :heavy_check_mark: | [bitcoinjs/bech32](https://github.com/bitcoinjs/bech32)
-[cardano-addresses]         | Addresses and mnemonic manipulation & derivations                        | :heavy_check_mark: | :construction:
-[cardano-coin-selection]    | Coin selection and fee balancing algorithms                              | :heavy_check_mark: | :construction:
-[cardano-launcher]          | Shelley cardano-node and cardano-wallet launcher for NodeJS applications | :x:                | :heavy_check_mark:
-[cardano-serialization-lib] | Binary serialization of on-chain data types                              | :construction:     | :construction:
-[cardano-transactions]      | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
+Name / Link                    | Description                                                              | Haskell            | JavaScript
+---                            | ---                                                                      | ---                | ---
+[bech32]                       | Human-friendly Bech32 address encoding                                   | :heavy_check_mark: | [bitcoinjs/bech32](https://github.com/bitcoinjs/bech32)
+[cardano-addresses]            | Addresses and mnemonic manipulation & derivations                        | :heavy_check_mark: | :construction:
+[cardano-coin-selection]       | Coin selection and fee balancing algorithms                              | :heavy_check_mark: | :construction:
+[cardano-launcher]             | Shelley cardano-node and cardano-wallet launcher for NodeJS applications | :x:                | :heavy_check_mark:
+[cardano-serialization-lib]    | Binary serialization of on-chain data types                              | :construction:     | :construction:
+[react-native-haskell-shelley] | Mobile bindings for [cardano-serialization-lib] w/ react-native support  | :construction:     | :construction:
+[cardano-transactions]         | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
 
 ## Formal Specifications 
 
@@ -55,6 +56,7 @@ name / link        | description
 [cardano-addresses]: https://github.com/input-output-hk/cardano-addresses
 [cardano-transactions]: https://github.com/input-output-hk/cardano-transactions
 [cardano-serialization-lib]: https://github.com/Emurgo/cardano-serialization-lib 
+[react-native-haskell-shelley]: https://github.com/Emurgo/react-native-haskell-shelley
 [bech32]: https://github.com/input-output-hk/bech32
 [utxo-wallet-specification]: https://github.com/input-output-hk/utxo-wallet-specification
 [cardano-launcher]: https://github.com/input-output-hk/cardano-launcher

--- a/README.md
+++ b/README.md
@@ -19,27 +19,36 @@ name / link       | description                                    | Byron      
 [cardano-graphql] | GraphQL/HTTP API for browsing on-chain data    | :heavy_check_mark: | :x:                | :construction:
 
 
-## Haskell SDKs (+JS support)
+## CLIs
 
-Name / Link                    | Description                                                              | Haskell            | JavaScript
----                            | ---                                                                      | ---                | ---
-[bech32]                       | Human-friendly Bech32 address encoding                                   | :heavy_check_mark: | [bitcoinjs/bech32](https://github.com/bitcoinjs/bech32)
-[cardano-addresses]            | Addresses and mnemonic manipulation & derivations                        | :heavy_check_mark: | :construction:
-[cardano-coin-selection]       | Coin selection and fee balancing algorithms                              | :heavy_check_mark: | :construction:
-[cardano-transactions]         | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
+Name / Link            | Description                                          | Byron              | Jörmungandr        | Shelley
+---                    | ---                                                  | ---                | ---                | ---
+[bech32]               | Human-friendly Bech32 address encoding               | N/A                | :heavy_check_mark: | :heavy_check_mark:
+[cardano-wallet]       | Command-line for interacting with cardano-wallet API | :heavy_check_mark: | :heavy_check_mark: | :construction:
+[cardano-addresses]    | Addresses and mnemonic manipulation & derivations    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+[cardano-transactions] | Transaction construction and signing                 | :heavy_check_mark: | :x:                | :construction:
 
-## Rust SDKs (+JS support)
+## Haskell SDKs 
 
-Name / Link                    | Description                                                              | Rust               | JavaScript
----                            | ---                                                                      | ---                | ---
-[cardano-serialization-lib]    | Binary serialization of on-chain data types                              | :construction:     | :construction:
-[react-native-haskell-shelley] | React Native bindings for [cardano-serialization-lib]                    | :construction:     | :construction:
+Name / Link              | Description                                       | Byron              | Jörmungandr        | Shelley
+---                      | ---                                               | ---                | ---                | ---
+[bech32]                 | Human-friendly Bech32 address encoding            | N/A                | :heavy_check_mark: | :heavy_check_mark:
+[cardano-addresses]      | Addresses and mnemonic manipulation & derivations | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+[cardano-coin-selection] | Coin selection and fee balancing algorithms       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
+[cardano-transactions]   | Transaction construction and signing              | :heavy_check_mark: | :x:                | :construction:
 
-## Pure JS SDKs
+## Rust SDKs (+WebAssembly support)
 
-Name / Link                    | Description
----                            | ---
-[cardano-launcher]             | Shelley cardano-node and cardano-wallet launcher for NodeJS applications
+Name / Link                    | Description                                           | Byron | Jörmungandr | Shelley
+---                            | ---                                                   | ---   | ---         | ---
+[cardano-serialization-lib]    | Binary serialization of on-chain data types           | N/A   | N/A         | :construction:
+[react-native-haskell-shelley] | React Native bindings for [cardano-serialization-lib] | N/A   | N/A         | :construction:
+
+## JavaScript SDKs
+
+Name / Link        | Description                                              | Byron              | Jörmungandr        | Shelley
+---                | ---                                                      | ---                | ---                | ---
+[cardano-launcher] | node and cardano-wallet launcher for NodeJS applications | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:
 
 ## Formal Specifications 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Name / Link                    | Description                                    
 Name / Link                    | Description                                                              | Rust               | JavaScript
 ---                            | ---                                                                      | ---                | ---
 [cardano-serialization-lib]    | Binary serialization of on-chain data types                              | :construction:     | :construction:
-[react-native-haskell-shelley] | Mobile bindings for [cardano-serialization-lib] w/ react-native support  | :construction:     | :construction:
+[react-native-haskell-shelley] | React Native bindings for [cardano-serialization-lib]                    | :construction:     | :construction:
 
 ### Pure JS SDKs
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ name / link       | description                                    | Byron      
 [cardano-graphql] | GraphQL/HTTP API for browsing on-chain data    | :heavy_check_mark: | :x:                | :construction:
 
 
-## SDK
-
-### Haskell SDKs (+JS support)
+## Haskell SDKs (+JS support)
 
 Name / Link                    | Description                                                              | Haskell            | JavaScript
 ---                            | ---                                                                      | ---                | ---
@@ -30,14 +28,14 @@ Name / Link                    | Description                                    
 [cardano-coin-selection]       | Coin selection and fee balancing algorithms                              | :heavy_check_mark: | :construction:
 [cardano-transactions]         | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
 
-### Rust SDKs (+JS support)
+## Rust SDKs (+JS support)
 
 Name / Link                    | Description                                                              | Rust               | JavaScript
 ---                            | ---                                                                      | ---                | ---
 [cardano-serialization-lib]    | Binary serialization of on-chain data types                              | :construction:     | :construction:
 [react-native-haskell-shelley] | React Native bindings for [cardano-serialization-lib]                    | :construction:     | :construction:
 
-### Pure JS SDKs
+## Pure JS SDKs
 
 Name / Link                    | Description
 ---                            | ---

--- a/README.md
+++ b/README.md
@@ -21,15 +21,27 @@ name / link       | description                                    | Byron      
 
 ## SDK
 
+### Haskell SDKs (+JS support)
+
 Name / Link                    | Description                                                              | Haskell            | JavaScript
 ---                            | ---                                                                      | ---                | ---
 [bech32]                       | Human-friendly Bech32 address encoding                                   | :heavy_check_mark: | [bitcoinjs/bech32](https://github.com/bitcoinjs/bech32)
 [cardano-addresses]            | Addresses and mnemonic manipulation & derivations                        | :heavy_check_mark: | :construction:
 [cardano-coin-selection]       | Coin selection and fee balancing algorithms                              | :heavy_check_mark: | :construction:
-[cardano-launcher]             | Shelley cardano-node and cardano-wallet launcher for NodeJS applications | :x:                | :heavy_check_mark:
+[cardano-transactions]         | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
+
+### Rust SDKs (+JS support)
+
+Name / Link                    | Description                                                              | Rust               | JavaScript
+---                            | ---                                                                      | ---                | ---
 [cardano-serialization-lib]    | Binary serialization of on-chain data types                              | :construction:     | :construction:
 [react-native-haskell-shelley] | Mobile bindings for [cardano-serialization-lib] w/ react-native support  | :construction:     | :construction:
-[cardano-transactions]         | Transaction construction and signing                                     | :heavy_check_mark: | :construction:
+
+### Pure JS SDKs
+
+Name / Link                    | Description
+---                            | ---
+[cardano-launcher]             | Shelley cardano-node and cardano-wallet launcher for NodeJS applications
 
 ## Formal Specifications 
 


### PR DESCRIPTION
I added our latest library https://github.com/Emurgo/react-native-haskell-shelley to the list.
I also decided to split the tables based on the underlying programming language since otherwise the `Haskell` column didn't really make sense.