### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,8 @@ jobs:
       - name: '❄ Install Nix'
         uses: cachix/install-nix-action@v16
         with:
+          install_url: https://releases.nixos.org/nix/nix-2.6.0/install
+          nix_path: nixpkgs=channel:nixos-21.11
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = https://hydra.iohk.io https://cache.nixos.org/

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,13 @@
   "nodes": {
     "ema": {
       "inputs": {
-        "flake-compat": [
-          "emanote",
-          "flake-compat"
-        ],
+        "flake-compat": "flake-compat",
         "flake-utils": [
-          "emanote",
           "flake-utils"
         ],
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -23,20 +21,21 @@
       },
       "original": {
         "owner": "srid",
-        "ref": "master",
         "repo": "ema",
         "type": "github"
       }
     },
     "emanote": {
       "inputs": {
-        "ema": "ema",
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
+        "ema": [
+          "ema"
+        ],
+        "flake-compat": "flake-compat_2",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "heist": "heist",
         "nixpkgs": [
-          "emanote",
-          "ema",
           "nixpkgs"
         ],
         "tailwind-haskell": "tailwind-haskell"
@@ -58,6 +57,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1627913399,
         "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
         "owner": "edolstra",
@@ -71,7 +86,23 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1641205782,
@@ -104,11 +135,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -166,22 +197,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1641521701,
-        "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1619531122,
         "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
         "owner": "NixOS",
@@ -192,6 +207,22 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1641577433,
+        "narHash": "sha256-T7lS8vpbC3dgtrkb2ueC9HWaX4RYUwdP7IEttnvKQ8Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "568e0bc498ee51fdd88e1e94089de05f2fdbd18b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "568e0bc498ee51fdd88e1e94089de05f2fdbd18b",
+        "type": "github"
       }
     },
     "nixpkgs_3": {
@@ -210,24 +241,24 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1643148353,
-        "narHash": "sha256-VMX2quZAFjCoAFzQX23ALsLNA7Y6d6qSNIvz1ySj2iY=",
+        "lastModified": 1641521701,
+        "narHash": "sha256-IuW+4EqqKjNdJ4yO0Qr8k63OkyV1TaF5vsrZzU3GCfI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3d86c56c786ad9530f1400adbd4dfac3c42877b",
+        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.11",
         "repo": "nixpkgs",
+        "rev": "d77bbfcbb650d9c219ca3286e1efb707b922d7c2",
         "type": "github"
       }
     },
     "pre-commit-hooks": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1639823344,
@@ -245,6 +276,7 @@
     },
     "root": {
       "inputs": {
+        "ema": "ema",
         "emanote": "emanote",
         "flake-utils": "flake-utils_4",
         "nixpkgs": "nixpkgs_4"
@@ -252,19 +284,9 @@
     },
     "tailwind-haskell": {
       "inputs": {
-        "flake-compat": [
-          "emanote",
-          "flake-compat"
-        ],
-        "flake-utils": [
-          "emanote",
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "emanote",
-          "ema",
-          "nixpkgs"
-        ],
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2",
         "tailwind-nix": "tailwind-nix"
       },
       "locked": {
@@ -284,7 +306,7 @@
     },
     "tailwind-nix": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_4",
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,23 @@
   description = "Adrestia Project Tools";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-21.11;
+    # nixpkgs.url = github:NixOS/nixpkgs/nixos-21.11;
+    nixpkgs.url = github:NixOS/nixpkgs/d77bbfcbb650d9c219ca3286e1efb707b922d7c2;
     flake-utils.url = github:numtide/flake-utils;
-    emanote.url = github:srid/emanote;
+    emanote = {
+      url = github:srid/emanote;
+      inputs.ema.follows = "ema";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+    ema = {
+      url = github:srid/ema;
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, emanote }:
+  outputs = { self, nixpkgs, flake-utils, emanote, ema }:
     flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (system: let
       pkgs = nixpkgs.legacyPackages.${system};
 


### PR DESCRIPTION
For some reason the nix flake works locally for me, but doesn't work on GitHub actions.

```
> Run nix develop --command emanote --version
error: input 'emanote/nixpkgs' follows a non-existent input 'ema/nixpkgs'
(use '--show-trace' to show detailed location information)
Error: Process completed with exit code 1.
```

This PR fiddles the flake inputs and also pins the nix version at Nix 2.6.0.
